### PR TITLE
Querying Wikipedia is now done in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Custom
 *test*
 *sandbox*
-.vscode/*
+.vscode/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Custom
 *test*
 *sandbox*
-.vscode
+.vscode/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Custom
 *test*
 *sandbox*
+.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/bin/python3"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/bin/python3"
-}

--- a/sandbox.py
+++ b/sandbox.py
@@ -1,58 +1,29 @@
-from urllib import request, parse
 import json
 import os
+from numpy import isin
+import requests
+from typing import Union
+from urllib import parse, error
 
+headers = {'User-Agent': 'AutoankiBot/0.1 (https://github.com/Eliclax/autoanki; tw2000x@gmail.com)'}
 
+def foo():
+    try:
+        resp = requests.get('https://en.wikipedia.org/w/api.php?action=opensearch&search=&limit=10&namespace=0&format=json', headers=headers)
+        resp.raise_for_status()
+        print(resp.status_code)
 
-def getWikiPageviews(
-    searchPhrase: str = "", 
-    article: str = "", 
-    project: str = "en.wikipedia.org",
-    access: str = "all-access",
-    agent: str = "user",
-    granularity: str = "monthly",
-    start: str = "20150701",
-    end: str = "20230101"
-    ) -> int:
-    """
-    Gets the Wikipedia pageviews over a timeframe, given a Wikipedia Search phrase or article. If using a search phrase, but there are no search results, returns 0. See https://wikimedia.org/api/rest_v1/#
+    except requests.HTTPError as err:
+        print("Helllllo")
+        raise
 
-    :param searchPhrase: What to search Wikipedia for.  The first page returned will be used.  If none are returned this function will return 0.
-    :param article: The title of any article in the specified project. Any spaces should be replaced with underscores. It also should be URI-encoded, so that non-URI-safe characters like %, / or ? are accepted. Example: Are_You_the_One%3F.
-    :param project: If you want to filter by project, use the domain of any Wikimedia project, for example 'en.wikipedia.org', 'www.mediawiki.org' or 'commons.wikimedia.org'.
-    :param access: If you want to filter by access method, use one of desktop, mobile-app or mobile-web. If you are interested in pageviews regardless of access method, use all-access. Available values : all-access, desktop, mobile-app, mobile-web
-    :param agent: If you want to filter by agent type, use one of user, automated or spider. If you are interested in pageviews regardless of agent type, use all-agents. Available values : all-agents, user, spider, automated
-    :param granularity: The time unit for the response data. As of today, the only supported granularity for this endpoint is daily and monthly. Available values : daily, monthly
-    :param start: The date of the first day to include, in YYYYMMDD or YYYYMMDDHH format
-    :param end: The date of the last day to include, in YYYYMMDD or YYYYMMDDHH format
-    :return: The number of pageviews
-    """
+def main():
+    try:
+        foo()
+    except requests.HTTPError as err:
+        print("Hello, Earth!")
+    except Exception as err:
+        if isinstance(err, requests.HTTPError):
+            print("Hello, World!")
 
-    assert article != "" or searchPhrase != ""
-
-    print("Article: " + article)
-
-    if article == "":
-        #SEE https://stackoverflow.com/questions/27457977/searching-wikipedia-using-api
-        searchUrl = "https://en.wikipedia.org/w/api.php?action=opensearch&search="
-        searchUrl += parse.quote(searchPhrase)
-        searchUrl += "&limit=10&namespace=0&format=json"
-        search_result = json.loads(request.urlopen(searchUrl).read())
-        #print(search_result)
-        article = os.path.basename(parse.urlparse(search_result[3][0]).path)
-        # notes[i]["url_bit"] = url_bit
-        # notes[i]["wikiUrls"] = copy.deepcopy(search_result[3])
-        print("Article: " + article)
-
-    pageviews = 0
-    wikiUrl = "https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/"
-    wikiUrl += "{}/{}/{}/{}/{}/{}/{}".format(project, access, agent, article, granularity, start, end)
-    contents = json.loads(request.urlopen(wikiUrl).read())
-    for item in contents["items"]:
-        #print(item)
-        pageviews += item["views"]
-    return pageviews
-
-
-
-print(getWikiPageviews("Joe Biden", ""))
+main()

--- a/src/orderanki/wiki-aiohttp.py
+++ b/src/orderanki/wiki-aiohttp.py
@@ -1,65 +1,62 @@
+from urllib import request, parse
 import json
 import os
-import requests
 from typing import Union
-from urllib import parse
 
-# If running this module by itself for dev purposes, you can change the verbosity by changing the "v: int = 1" line
+from aiohttp.client import ClientSession
+import asyncio
+
+# If running this module by itself for dev purposes, you can change the verbosity by changing the "v = 1" line
 verbose: int = 0
-v: int = 1
-
-headers = {'User-Agent': 'AutoankiBot/0.1 (https://github.com/Eliclax/autoanki; tw2000x@gmail.com)'}
+v = 1
 
 if __name__ == "__main__":
     verbose = v
 
-def searchArticleUrl(searchPhrase: str, timeout: float = 5) -> Union[str, None]:
+async def searchArticleUrl(searchPhrase : str, session: ClientSession) -> Union[str, None]:
     """
     Given a search phrase, returns the top result after Searching en.wikipedia.org
 
-    :param searchPhrase: The sdearch phrase that you want to search en.wikipedia.org with.
-    :param timeout: How many seconds to wait for the server to send data before giving up.
+    :param searchPhrase: The sdearch phrase that you want to search en.wikipedia.org with
+    :param session: The ClientSession.  See aiohttp.ClientSession
     :return: The title of the article, as a URL string.
     """
 
     searchUrl = "https://en.wikipedia.org/w/api.php?action=opensearch&search="
     searchUrl += parse.quote(searchPhrase)
     searchUrl += "&limit=10&namespace=0&format=json"
-    try:
-        resp = requests.get(searchUrl, headers=headers, timeout=timeout)
-        resp.raise_for_status()
-    except requests.HTTPError:
-        raise
-    search_result = resp.json()
-    try:
-        article = os.path.basename(parse.urlparse(search_result[3][0]).path)
-    except:
-        return None
+    print("Searching {}".format(searchPhrase))
+    resp = await session.get(searchUrl)
+    await asyncio.sleep(1)
+    print("Done searching {}".format(searchPhrase))
+    resp.raise_for_status()
+    search_result = json.loads(await resp.text())
+    article = os.path.basename(parse.urlparse(search_result[3][0]).path)
     if verbose >= 1:
         print("   > Searched: {} -> {}".format(searchPhrase, article))
     return article
 
-def getPageviews(
+async def getPageviews(
     article: Union[str, None], 
+    session: ClientSession,
     project: str = "en.wikipedia.org",
     access: str = "all-access",
     agent: str = "user",
     granularity: str = "monthly",
     start: str = "20150701",
     end: str = "20230101",
-    timeout: float = 5
     ) -> int:
     """
     Gets the Wikipedia pageviews over a timeframe, given a URL-encoded Wikipedia article title. If empty, returns 0. See https://wikimedia.org/api/rest_v1/#
 
     :param article: The title of any article in the specified project. Any spaces should be replaced with underscores. It also should be URI-encoded, so that non-URI-safe characters like %, / or ? are accepted. Example: Are_You_the_One%3F.
+    :param session: The ClientSession.  See aiohttp.ClientSession
     :param project: If you want to filter by project, use the domain of any Wikimedia project, for example 'en.wikipedia.org', 'www.mediawiki.org' or 'commons.wikimedia.org'.
     :param access: If you want to filter by access method, use one of desktop, mobile-app or mobile-web. If you are interested in pageviews regardless of access method, use all-access. Available values : all-access, desktop, mobile-app, mobile-web
     :param agent: If you want to filter by agent type, use one of user, automated or spider. If you are interested in pageviews regardless of agent type, use all-agents. Available values : all-agents, user, spider, automated
     :param granularity: The time unit for the response data. As of today, the only supported granularity for this endpoint is daily and monthly. Available values : daily, monthly
     :param start: The date of the first day to include, in YYYYMMDD or YYYYMMDDHH format
     :param end: The date of the last day to include, in YYYYMMDD or YYYYMMDDHH format
-    :param timeout: How many seconds to wait for the server to send data before giving up.
     :return: The number of pageviews
     """
 
@@ -67,26 +64,29 @@ def getPageviews(
         return 0
 
     pageviews = 0
-    if article != "":
-        wikiUrl = "https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/"
-        wikiUrl += "{}/{}/{}/{}/{}/{}/{}".format(project, access, agent, article, granularity, start, end)
-        try:
-            resp = requests.get(wikiUrl, headers=headers, timeout=timeout)
-            resp.raise_for_status()
-        except requests.HTTPError:
-            raise
-        contents: str = resp.json()
-        if verbose >= 2:
-            print(json.dumps(contents, indent=4))
+    wikiUrl = "https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/"
+    wikiUrl += "{}/{}/{}/{}/{}/{}/{}".format(project, access, agent, article, granularity, start, end)
+    resp = await session.get(wikiUrl)
+    resp.raise_for_status()
+    contents = json.loads(await resp.text())
+    if verbose >= 2:
+        print(json.dumps(json.loads(contents), indent=4))
     for item in contents["items"]:
         pageviews += item["views"]
     if verbose >= 1:
         print("   > Queried: {:14d} | {}".format(pageviews, article))
     return pageviews
 
+    
 if __name__ == "__main__":
-    getPageviews("Noodle")
-    getPageviews("")
-    getPageviews("Donald_Trump")
-    searchArticleUrl("Noodles")
-    getPageviews(searchArticleUrl("Stoke on Trent"))
+    async def setup():
+        async with ClientSession() as session:
+            await asyncio.gather()
+            await getPageviews("Staffordshire", session)
+            await getPageviews("Noodle", session)
+            await getPageviews("", session)
+            await getPageviews("Donald_Trump", session)
+            await searchArticleUrl("Noodles", session)
+            await getPageviews(await searchArticleUrl("Stoke on Trent", session), session)
+
+    asyncio.run(setup())


### PR DESCRIPTION
Using a multi-threading producers and consumers pattern, Wikipedia searching and pageview querying are now done in parallel.  Handles exception cases and when there are no search results.  Updated the progress bar and UI to fit.